### PR TITLE
feat: configure Claude Code local installation setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 config/claude/projects/
 config/claude/todos/
 
+# Claude Code local installation and shell snapshots
+config/claude/local/
+config/claude/shell-snapshots/
+
 # macOS system files
 .DS_Store
 .DS_Store?

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -1,4 +1,11 @@
 {
+  "env": {
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    "CLAUDE_CODE_USE_VERTEX": "1",
+    "CLOUD_ML_REGION": "us-east5",
+    "ANTHROPIC_VERTEX_PROJECT_ID": "wp-engine-ai"
+  },
+  "includeCoAuthoredBy": false,
   "permissions": {
     "allow": [
       "WebFetch",
@@ -9,11 +16,7 @@
     ],
     "deny": []
   },
-  "includeCoAuthoredBy": false,
-  "env": {
-    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": 1,
-    "CLAUDE_CODE_USE_VERTEX": 1,
-    "CLOUD_ML_REGION": "us-east5",
-    "ANTHROPIC_VERTEX_PROJECT_ID": "wp-engine-ai"
+  "feedbackSurveyState": {
+    "lastShownTime": 1753978459036
   }
 }

--- a/shell/.aliases
+++ b/shell/.aliases
@@ -8,6 +8,9 @@ alias dotfiles="cd $HOME/.dotfiles"
 alias library="cd $HOME/Library"
 alias notes="cd $HOME/notes"
 alias workspace="cd $HOME/workspace"
+
+# === Claude Code ===
+alias claude="$HOME/.claude/local/claude"
 alias downloads="cd /private/tmp/downloads"
 
 # === System Commands ===


### PR DESCRIPTION
## Summary
Configure dotfiles for Claude Code local installation, including proper gitignore rules and shell alias setup.

## Changes
- **Settings Configuration**: Reorganize Claude Code settings.json structure and add feedback survey tracking
- **Git Configuration**: Add gitignore rules for Claude Code local installation and shell snapshot directories
- **Shell Enhancement**: Add portable claude alias using $HOME variable instead of hardcoded paths

## Testing
- ✅ Verified alias works with `$HOME` variable for portability
- ✅ Confirmed gitignore excludes appropriate local files
- ✅ Settings format validated and feedback tracking operational

## Files Changed
- `.gitignore` - Added Claude Code local install exclusions
- `config/claude/settings.json` - Reorganized structure and added feedback tracking
- `shell/.aliases` - Added portable claude command alias

This change ensures the dotfiles repository remains clean and portable while supporting both global and local Claude Code installations.